### PR TITLE
modify concate axis to 2

### DIFF
--- a/models/ops.py
+++ b/models/ops.py
@@ -102,7 +102,7 @@ def CBHG(inputs, speaker_embed=None,
                 if speaker_embed is not None:
                     s = tf.layers.dense(speaker_embed, h.shape[-1], activation=tf.nn.relu)
                     s = tf.tile(tf.expand_dims(s, 1), [1, tf.shape(h)[1], 1])
-                    h = tf.concat([h, s], 1)
+                    h = tf.concat([h, s], 2)
 
                 h = highway(h)
 


### PR DESCRIPTION
I think it's more reasonable to concate `highway input` with `speaker embedding` at the `last` axis. Is this right?